### PR TITLE
add extra_configs support for local platformio env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .pio
 .vscode
 .private
+platformio_custom.ini
 src/main*.cpp
 src/main*.h
 src/madflight_config.h

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,7 +12,9 @@
 ; or create 'src/main.cpp' with one line: #include "../examples/00.HelloWorld/main.cpp"
 
 [platformio]
-; Uncomment ONE line to set the default env to compile, instead of "all environments"
+extra_configs = platformio_custom.ini
+; Store personal environments into separate file platformio_custom.ini. This file is gitignored.
+; Or uncomment ONE line to set the default env to compile, instead of "all environments"
 ;default_envs = ESP32
 ;default_envs = ESP32-S3
 ;default_envs = RP2040


### PR DESCRIPTION
Add platformio_custom.ini as an extra_configs entry so developers can define personal board environments (e.g. [env:m5stampfly]) without modifying the tracked platformio.ini. The file is gitignored to keep local configs out of the repository.

Example:
```
$ cat platformio_custom.ini
[env:M5STAMPFLY]
board = esp32-s3-devkitc-1
platform = espressif32
framework = arduino
monitor_filters = esp32_exception_decoder
build_flags =
    -D ARDUINO_USB_MODE=1
    -D ARDUINO_USB_CDC_ON_BOOT=1
```