### PR TITLE
Add BMM150 to cfg options additional andtiny fixes

### DIFF
--- a/examples/00.HelloWorld/madflight_config.h
+++ b/examples/00.HelloWorld/madflight_config.h
@@ -60,7 +60,7 @@ const char madflight_config[] = R""(
 //bar_i2c_bus   -1
 
 //--- MAG --- Magnetometer
-//mag_gizmo      NONE  // options: NONE, QMC6309, QMC5883L, QMC5883P, RM3100
+//mag_gizmo      NONE  // options: NONE, QMC6309, QMC5883L, QMC5883P, RM3100, BMM150
 //mag_align      CW0   // options: CW0, CW90, CW180, CW270, CW0FLIP, CW90FLIP, CW180FLIP, CW270FLIP
 //mag_i2c_adr    0
 //mag_i2c_bus   -1

--- a/examples/10.Quadcopter/madflight_config.h
+++ b/examples/10.Quadcopter/madflight_config.h
@@ -60,7 +60,8 @@ const char madflight_config[] = R""(
 //bar_i2c_bus   -1
 
 //--- MAG --- Magnetometer
-//mag_gizmo      NONE  // options: NONE, QMC6309, QMC5883L, QMC5883P, RM3100
+//mag_gizmo      NONE  // options: NONE, QMC6309, QMC5883L, QMC5883P, RM3100, BMM150
+
 //mag_align      CW0   // options: CW0, CW90, CW180, CW270, CW0FLIP, CW90FLIP, CW180FLIP, CW270FLIP
 //mag_i2c_adr    0
 //mag_i2c_bus   -1

--- a/examples/11.QuadcopterAdvanced/madflight_config.h
+++ b/examples/11.QuadcopterAdvanced/madflight_config.h
@@ -60,7 +60,7 @@ const char madflight_config[] = R""(
 //bar_i2c_bus   -1
 
 //--- MAG --- Magnetometer
-//mag_gizmo      NONE  // options: NONE, QMC6309, QMC5883L, QMC5883P, RM3100
+//mag_gizmo      NONE  // options: NONE, QMC6309, QMC5883L, QMC5883P, RM3100, BMM150
 //mag_align      CW0   // options: CW0, CW90, CW180, CW270, CW0FLIP, CW90FLIP, CW180FLIP, CW270FLIP
 //mag_i2c_adr    0
 //mag_i2c_bus   -1

--- a/examples/20.Plane/madflight_config.h
+++ b/examples/20.Plane/madflight_config.h
@@ -60,7 +60,7 @@ const char madflight_config[] = R""(
 //bar_i2c_bus   -1
 
 //--- MAG --- Magnetometer
-//mag_gizmo      NONE  // options: NONE, QMC6309, QMC5883L, QMC5883P, RM3100
+//mag_gizmo      NONE  // options: NONE, QMC6309, QMC5883L, QMC5883P, RM3100, BMM150
 //mag_align      CW0   // options: CW0, CW90, CW180, CW270, CW0FLIP, CW90FLIP, CW180FLIP, CW270FLIP
 //mag_i2c_adr    0
 //mag_i2c_bus   -1

--- a/src/mag/MagGizmoBMM150.h
+++ b/src/mag/MagGizmoBMM150.h
@@ -26,7 +26,7 @@ class MagGizmoBMM150: public MagGizmo {
       //configure sensor
       BMM150_I2C *sensor = new BMM150_I2C(i2c, config->i2c_adr);
       if(sensor->begin() != 0) {
-        Serial.printf("RDR: BMM150 init failed.\n");
+        Serial.printf("MAG: BMM150 init failed.\n");
         delete sensor;
         return nullptr;
       }

--- a/src/out/out.h
+++ b/src/out/out.h
@@ -73,7 +73,7 @@ class Out : public OutState {
     bool setup_dshot(uint8_t cnt, int* idxs, int freq_khz = 300);
     bool setup_dshot_bidir(uint8_t cnt, int* idxs, int freq_khz = 300);
     bool setup_motors(uint8_t cnt, int* idxs, int freq_hz = 400, int pwm_min_us = 950, int pwm_max_us = 2000);
-    bool setup_brushed(uint8_t cnt, int* idxs, int freq_khz);
+    bool setup_brushed(uint8_t cnt, int* idxs, int freq_hz);
     bool setup_motor(uint8_t idx, int freq_hz = 400, int pwm_min_us = 950, int pwm_max_us = 2000);
     bool setup_servo(uint8_t idx, int freq_hz = 400, int pwm_min_us = 950, int pwm_max_us = 2000);
     void set_output(uint8_t idx, float value); //set output (when ARMED, ignored in DISARMED and TESTMOTOR mode)


### PR DESCRIPTION
Add BMM150 to mag_gizmo comment options across all example configs. Fix incorrect "RDR:" log prefix to "MAG:" in MagGizmoBMM150 init error message. Rename setup_brushed() freq parameter from freq_khz to freq_hz to match actual units.