### PR TITLE
Fix #112 watchdog race in Out::update() causing spurious disarm

### DIFF
--- a/src/out/out.cpp
+++ b/src/out/out.cpp
@@ -178,7 +178,11 @@ int Out::eperiod_to_rpm(int eperiod, int poles) {
 
 bool Out::update() {
   //disarm motors after timeout
-  if(_mode != mode_enum::DISARMED && micros() - _watchdog_ts >= OUT_MOT_TIMEOUT) {
+  //snapshot _watchdog_ts before reading micros() - if set_output() updates _watchdog_ts
+  //between these two reads, micros() - wd_ts underflows as unsigned and spuriously trips the timeout
+  uint32_t wd_ts = _watchdog_ts;
+  uint32_t now = micros();
+  if(_mode != mode_enum::DISARMED && now - wd_ts >= OUT_MOT_TIMEOUT) {
      _set_mode(mode_enum::DISARMED);
   }
 

--- a/src/out/out.h
+++ b/src/out/out.h
@@ -107,7 +107,7 @@ class Out : public OutState {
     int _dshot_idxs[OUT_SIZE]; //dshot out indices
 
     uint32_t _update_ts = 0;
-    uint32_t _watchdog_ts = 0;
+    volatile uint32_t _watchdog_ts = 0;
 
 
 };


### PR DESCRIPTION
Fixes #112

## Problem

`Out::update()` checks the motor watchdog with:

```cpp
if(_mode != mode_enum::DISARMED && micros() - _watchdog_ts >= OUT_MOT_TIMEOUT) {
   _set_mode(mode_enum::DISARMED);
}
```

C++ does not specify evaluation order between the `micros()` call and the load of `_watchdog_ts`. If `set_output()` (or `testmotor_set_output()`) updates `_watchdog_ts` from another task/core between those two reads, `micros()` can be sampled with an older value while `_watchdog_ts` is reloaded with a newer one. The unsigned subtraction then underflows to a value far greater than `OUT_MOT_TIMEOUT`, the comparison trips, and the motors are spuriously disarmed mid-flight — exactly the `OUT: ARMED` stutter the reporter observed.

The reporter (@slavicd) hardware-verified on an Arduino Nano ESP32 that snapshotting both values into locals before the comparison makes the stutter unreproducible.

## Fix

- Snapshot `_watchdog_ts` into a local before reading `micros()`, locking in evaluation order.
- Mark `_watchdog_ts` as `volatile` so the compiler cannot reload it between the two references or hoist the load across the `micros()` call.

## Architectures

`_watchdog_ts` is `uint32_t`, so individual loads/stores are already atomic on every supported target (ESP32-S3/ESP32, RP2350/RP2040, STM32 — all 32-bit cores). No platform-specific atomics or critical sections are needed; the fix is portable C++ and compiles cleanly under both Arduino IDE and PlatformIO.

## Audit

All readers and writers of `_watchdog_ts` were audited:
- Reader: `Out::update()` (line 181) — fixed
- Writers: `Out::set_output()`, `Out::testmotor_enable()`, `Out::testmotor_set_output()` — unchanged, none in ISR context

## Test plan

- Builds on ESP32, RP2, STM32 via the existing CI compile matrix.
- Behavioral verification by the original reporter on Arduino Nano ESP32 (their patch is functionally equivalent to this one).