### PR TITLE
Fixes MPU6500 not being detected on Arduino Nano ESP32

### DIFF
--- a/src/imu/MPUXXXX/MPUXXXX.cpp
+++ b/src/imu/MPUXXXX/MPUXXXX.cpp
@@ -68,8 +68,8 @@ int MPUXXXX::begin(MPU_Type type, SensorDevice *dev, int gyro_scale_dps, int acc
         Serial.printf("IMU: WARNING: MPU60X0 whoami mismatch, got:0x%02X expected:0x68, attempting autodetect\n",wai);
         _type = AUTO;
     }    
-    if(_type == MPU6500 && wai != 0x70) {
-        Serial.printf("IMU: WARNING: MPU6500 whoami mismatch, got:0x%02X expected:0x70, attempting autodetect\n",wai);
+    if(_type == MPU6500 && (wai != 0x70 && wai != 0x30)) {
+        Serial.printf("IMU: WARNING: MPU6500 whoami mismatch, got:0x%02X expected:0x70 or 0x30, attempting autodetect\n",wai);
         _type = AUTO;
     }
     if(_type == MPU9150 && wai != 0x68) {


### PR DESCRIPTION
More of a workaround than fix, but for some reason, as per [the discussion](https://github.com/qqqlab/madflight/discussions/116), MPU6500's response is seen as 0x30 in Madflight. The reason I say "in Madflight" is because a test with I2C (non-Madflight) returns the expected 0x70.