### PR TITLE
Prefer SPI_MODE0

### DIFF
--- a/src/bar/DPS310/DpsClass.cpp
+++ b/src/bar/DPS310/DpsClass.cpp
@@ -599,9 +599,7 @@ int16_t DpsClass::readByteSPI(uint8_t regAddress)
     // mask regAddress
     regAddress &= ~DPS3xx__SPI_RW_MASK;
     // reserve and initialize bus
-    m_spibus->beginTransaction(SPISettings(DPS3xx__SPI_MAX_FREQ,
-                                           MSBFIRST,
-                                           SPI_MODE3));
+    m_spibus->beginTransaction(SPISettings(DPS3xx__SPI_MAX_FREQ, MSBFIRST, SPI_MODE3)); //dps310 does not support SPI_MODE0
     // enable ChipSelect for Dps3xx
     digitalWrite(m_chipSelect, LOW);
     // send address with read command to Dps3xx
@@ -633,9 +631,7 @@ int16_t DpsClass::readBlockSPI(RegBlock_t regBlock, uint8_t *buffer)
     // mask regAddress
     regBlock.regAddress &= ~DPS3xx__SPI_RW_MASK;
     // reserve and initialize bus
-    m_spibus->beginTransaction(SPISettings(DPS3xx__SPI_MAX_FREQ,
-                                           MSBFIRST,
-                                           SPI_MODE3));
+    m_spibus->beginTransaction(SPISettings(DPS3xx__SPI_MAX_FREQ, MSBFIRST, SPI_MODE3)); //dps310 does not support SPI_MODE0
     // enable ChipSelect for Dps3xx
     digitalWrite(m_chipSelect, LOW);
     // send address with read command to Dps3xx
@@ -703,9 +699,7 @@ int16_t DpsClass::writeByteSpi(uint8_t regAddress, uint8_t data, uint8_t check)
     // mask regAddress
     regAddress &= ~DPS3xx__SPI_RW_MASK;
     // reserve and initialize bus
-    m_spibus->beginTransaction(SPISettings(DPS3xx__SPI_MAX_FREQ,
-                                           MSBFIRST,
-                                           SPI_MODE3));
+    m_spibus->beginTransaction(SPISettings(DPS3xx__SPI_MAX_FREQ, MSBFIRST, SPI_MODE3)); //dps310 does not support SPI_MODE0
     // enable ChipSelect for Dps3xx
     digitalWrite(m_chipSelect, LOW);
     // send address with read command to Dps3xx

--- a/src/bar/bmp3/bmp3.cpp
+++ b/src/bar/bmp3/bmp3.cpp
@@ -276,7 +276,7 @@ int8_t Bmp3::SpiWriteRegisters(uint8_t reg, const uint8_t * data,
     return BMP3_E_INVALID_LEN;
   }
   SpiIntf *iface = static_cast<SpiIntf *>(intf);
-  iface->spi->beginTransaction(SPISettings(SPI_CLK_, MSBFIRST, SPI_MODE3));
+  iface->spi->beginTransaction(SPISettings(SPI_CLK_, MSBFIRST, SPI_MODE0));
   #if defined(TEENSYDUINO)
   digitalWriteFast(iface->cs, LOW);
   #else
@@ -306,7 +306,7 @@ int8_t Bmp3::SpiReadRegisters(uint8_t reg, uint8_t * data, uint32_t len,
     return BMP3_E_INVALID_LEN;
   }
   SpiIntf *iface = static_cast<SpiIntf *>(intf);
-  iface->spi->beginTransaction(SPISettings(SPI_CLK_, MSBFIRST, SPI_MODE3));
+  iface->spi->beginTransaction(SPISettings(SPI_CLK_, MSBFIRST, SPI_MODE0));
   #if defined(TEENSYDUINO)
   digitalWriteFast(iface->cs, LOW);
   #else

--- a/src/imu/ImuGizmoBMI270.h
+++ b/src/imu/ImuGizmoBMI270.h
@@ -387,7 +387,7 @@ class ImuGizmoBMI270 : public ImuGizmo {
     }
 
     int8_t spi_read(const uint8_t reg, uint8_t * data, const uint32_t count) {
-        _spi->beginTransaction(SPISettings(spi_freq, MSBFIRST, SPI_MODE3));
+        _spi->beginTransaction(SPISettings(spi_freq, MSBFIRST, SPI_MODE0)); //bmi270 works with mode0+3, mode3 is buggy on esp32
         digitalWrite(_csPin, LOW);
         _spi->transfer(0x80 | reg);
         _spi->transfer(0); //dummy byte --- BMI270 specific ---
@@ -400,7 +400,7 @@ class ImuGizmoBMI270 : public ImuGizmo {
     }
 
     int8_t spi_write(uint8_t reg, const uint8_t *data, uint32_t count) {
-        _spi->beginTransaction(SPISettings(spi_freq, MSBFIRST, SPI_MODE3));
+        _spi->beginTransaction(SPISettings(spi_freq, MSBFIRST, SPI_MODE0)); //bmi270 works with mode0+3, mode3 is buggy on esp32
         digitalWrite(_csPin, LOW);
         _spi->transfer(reg);
         for (uint32_t k=0; k<count; k++) {

--- a/src/imu/common/SensorDevice.cpp
+++ b/src/imu/common/SensorDevice.cpp
@@ -33,13 +33,8 @@ SensorDevice* SensorDevice::createImuDevice(ImuConfig *config) {
     SensorDevice *dev = nullptr;
     if(config->spi_bus) {
         if(config->spi_cs >= 0) {
-            #ifdef ESP32
-            // Force Mode 0 on ESP32 to bypass hardware clock-glitch corruption (https://esp32.com/viewtopic.php?t=36723)
+            // Use Mode0 (Mode3 is buggy on ESP32 https://esp32.com/viewtopic.php?t=36723)
             dev = new SensorDeviceSPI(config->spi_bus, config->spi_cs, SPI_MODE0);
-            #else
-            // Fallback to standard Mode 3 for other platforms
-            dev = new SensorDeviceSPI(config->spi_bus, config->spi_cs, SPI_MODE3);
-            #endif
         }
     }else if(config->i2c_bus) {
         dev = new SensorDeviceI2C(config->i2c_bus, config->i2c_adr);

--- a/src/imu/common/SensorDevice.h
+++ b/src/imu/common/SensorDevice.h
@@ -71,7 +71,7 @@ class SensorDeviceSPI : public SensorDevice {
     uint8_t _spi_mode;
 
   public:
-    SensorDeviceSPI(SPIClass *spi, uint8_t cs, uint8_t spi_mode = SPI_MODE3) {
+    SensorDeviceSPI(SPIClass *spi, uint8_t cs, uint8_t spi_mode = SPI_MODE0) {
       _spi = spi; 
       _spi_cs = cs;
       _spi_mode = spi_mode;

--- a/src/ofl/PWM3901/Bitcraze_PMW3901.cpp
+++ b/src/ofl/PWM3901/Bitcraze_PMW3901.cpp
@@ -79,6 +79,8 @@ void pmw3901ReadMotion(uint32_t csPin, motionBurst_t *motion)
 
 #define CHIP_ID         0x49  // 01001001
 #define CHIP_ID_INVERSE 0xB6  // 10110110
+#define PWM3901_SPI_MODE SPI_MODE0 //not specified in datasheet, assume mode0+3, mode3 buggy on esp32
+#define PWM3901_SPI_FREQ 4000000 //datasheet 2MHz
 
 Bitcraze_PMW3901::Bitcraze_PMW3901(SPIClass* spi, uint8_t cspin)
   : _spi(spi), _cs(cspin)
@@ -88,7 +90,7 @@ bool Bitcraze_PMW3901::begin(void) {
   // Setup SPI port
   _spi->begin();
   pinMode(_cs, OUTPUT);
-  _spi->beginTransaction(SPISettings(4000000, MSBFIRST, SPI_MODE3));
+  _spi->beginTransaction(SPISettings(PWM3901_SPI_FREQ, MSBFIRST, PWM3901_SPI_MODE));
 
   // Make sure the SPI bus is reset
   digitalWrite(_cs, HIGH);
@@ -202,7 +204,7 @@ void Bitcraze_PMW3901::readFrameBuffer(char *FBuffer)
 void Bitcraze_PMW3901::registerWrite(uint8_t reg, uint8_t value) {
   reg |= 0x80u;
 
-  _spi->beginTransaction(SPISettings(4000000, MSBFIRST, SPI_MODE3));
+  _spi->beginTransaction(SPISettings(PWM3901_SPI_FREQ, MSBFIRST, PWM3901_SPI_MODE));
 
   digitalWrite(_cs, LOW);
 
@@ -221,7 +223,7 @@ void Bitcraze_PMW3901::registerWrite(uint8_t reg, uint8_t value) {
 uint8_t Bitcraze_PMW3901::registerRead(uint8_t reg) {
   reg &= ~0x80u;
 
-  _spi->beginTransaction(SPISettings(4000000, MSBFIRST, SPI_MODE3));
+  _spi->beginTransaction(SPISettings(PWM3901_SPI_FREQ, MSBFIRST, PWM3901_SPI_MODE));
 
   digitalWrite(_cs, LOW);
 


### PR DESCRIPTION
Use SPI_MODE0 if device supports it, because of buggy SPI_MODE3 on ESP32