### PR TITLE
Add option to use approximate math

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -43,6 +43,7 @@ monitor_echo = yes
 build_flags =
 ;  -D MF_DEBUG=1 ;uncomment to print additional debugging info
 ;  -D MF_BINLOG_I16_SCALED ;uncomment to use scaled 2 byte integers in the binlogs to create smaller logs, otherwise use 4 byte floats. Most visualisation software does not support scaled integers, and will show unscaled values. 
+;  -D MF_APPROX_MATH ;uncomment to use sin/cos/sqrt approximations. Keep this undefined to use precise libc sin/cos/sqrt.
 
 ;============================================================
 ; ESP32 TARGETS

--- a/src/ahr/Madgwick/Madgwick.cpp
+++ b/src/ahr/Madgwick/Madgwick.cpp
@@ -3,7 +3,8 @@
 //==============================================================================================================
 
 #include "Madgwick.h"
-#include <math.h> //sqrtf
+#include "../../tbx/maths.h" //rsqrt_approx
+#include <math.h> //sqrt
 
 
 void Madgwick::update(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz, float dt) {
@@ -41,13 +42,13 @@ void Madgwick::update9DOF(float gx, float gy, float gz, float ax, float ay, floa
   if (0.81 <= alen2 && alen2 <= 1.21) {
     
     //Normalise accelerometer measurement
-    recipNorm = 1.0/sqrtf(alen2);
+    recipNorm = rsqrt_approx(alen2);
     ax *= recipNorm;
     ay *= recipNorm;
     az *= recipNorm;
 
     //Normalise magnetometer measurement
-    recipNorm = 1.0/sqrtf(mx * mx + my * my + mz * mz);
+    recipNorm = rsqrt_approx(mx * mx + my * my + mz * mz);
     mx *= recipNorm;
     my *= recipNorm;
     mz *= recipNorm;
@@ -77,7 +78,7 @@ void Madgwick::update9DOF(float gx, float gy, float gz, float ax, float ay, floa
     //Reference direction of Earth's magnetic field
     hx = mx * q0q0 - _2q0my * q3 + _2q0mz * q2 + mx * q1q1 + _2q1 * my * q2 + _2q1 * mz * q3 - mx * q2q2 - mx * q3q3;
     hy = _2q0mx * q3 + my * q0q0 - _2q0mz * q1 + _2q1mx * q2 - my * q1q1 + my * q2q2 + _2q2 * mz * q3 - my * q3q3;
-    _2bx = sqrtf(hx * hx + hy * hy);
+    _2bx = sqrt(hx * hx + hy * hy);
     _2bz = -_2q0mx * q2 + _2q0my * q1 + mz * q0q0 + _2q1mx * q3 - mz * q1q1 + _2q2 * my * q3 - mz * q2q2 + mz * q3q3;
     _4bx = 2.0f * _2bx;
     _4bz = 2.0f * _2bz;
@@ -87,7 +88,7 @@ void Madgwick::update9DOF(float gx, float gy, float gz, float ax, float ay, floa
     s1 = _2q3 * (2.0f * q1q3 - _2q0q2 - ax) + _2q0 * (2.0f * q0q1 + _2q2q3 - ay) - 4.0f * q1 * (1 - 2.0f * q1q1 - 2.0f * q2q2 - az) + _2bz * q3 * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (_2bx * q2 + _2bz * q0) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + (_2bx * q3 - _4bz * q1) * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
     s2 = -_2q0 * (2.0f * q1q3 - _2q0q2 - ax) + _2q3 * (2.0f * q0q1 + _2q2q3 - ay) - 4.0f * q2 * (1 - 2.0f * q1q1 - 2.0f * q2q2 - az) + (-_4bx * q2 - _2bz * q0) * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (_2bx * q1 + _2bz * q3) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + (_2bx * q0 - _4bz * q2) * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
     s3 = _2q1 * (2.0f * q1q3 - _2q0q2 - ax) + _2q2 * (2.0f * q0q1 + _2q2q3 - ay) + (-_4bx * q3 + _2bz * q1) * (_2bx * (0.5f - q2q2 - q3q3) + _2bz * (q1q3 - q0q2) - mx) + (-_2bx * q0 + _2bz * q2) * (_2bx * (q1q2 - q0q3) + _2bz * (q0q1 + q2q3) - my) + _2bx * q1 * (_2bx * (q0q2 + q1q3) + _2bz * (0.5f - q1q1 - q2q2) - mz);
-    recipNorm = 1.0/sqrtf(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
+    recipNorm = rsqrt_approx(s0 * s0 + s1 * s1 + s2 * s2 + s3 * s3); // normalise step magnitude
     s0 *= recipNorm;
     s1 *= recipNorm;
     s2 *= recipNorm;
@@ -107,7 +108,7 @@ void Madgwick::update9DOF(float gx, float gy, float gz, float ax, float ay, floa
   q3 += qDot4 * dt;
 
   //Normalize quaternion
-  recipNorm = 1.0/sqrtf(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
+  recipNorm = rsqrt_approx(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
   q0 *= recipNorm;
   q1 *= recipNorm;
   q2 *= recipNorm;

--- a/src/ahr/Mahony/Mahony.cpp
+++ b/src/ahr/Mahony/Mahony.cpp
@@ -4,7 +4,8 @@
 //source: https://github.com/PaulStoffregen/MahonyAHRS
 
 #include "Mahony.h"
-#include <math.h> //sqrtf
+#include "../../tbx/maths.h" //rsqrt_approx
+#include <math.h> //sqrt
 
 void Mahony::update(float gx, float gy, float gz, float ax, float ay, float az, float mx, float my, float mz, float dt) {
   //Use 6DOF algorithm if magnetometer measurement invalid or unavailable (avoids NaN in magnetometer normalisation)
@@ -29,13 +30,13 @@ void Mahony::update9DOF(float gx, float gy, float gz, float ax, float ay, float 
   if (alen2 > config_alen2_min && alen2 < config_alen2_max) {
 
     //Normalise accelerometer measurement
-    recipNorm = 1.0 / sqrtf(alen2);
+    recipNorm = rsqrt_approx(alen2);
     ax *= recipNorm;
     ay *= recipNorm;
     az *= recipNorm;
 
     // Normalise magnetometer measurement
-    recipNorm = 1.0f/sqrtf(mx * mx + my * my + mz * mz);
+    recipNorm = rsqrt_approx(mx * mx + my * my + mz * mz);
     mx *= recipNorm;
     my *= recipNorm;
     mz *= recipNorm;
@@ -55,7 +56,7 @@ void Mahony::update9DOF(float gx, float gy, float gz, float ax, float ay, float 
     // Reference direction of Earth's magnetic field
     hx = 2.0f * (mx * (0.5f - q2q2 - q3q3) + my * (q1q2 - q0q3) + mz * (q1q3 + q0q2));
     hy = 2.0f * (mx * (q1q2 + q0q3) + my * (0.5f - q1q1 - q3q3) + mz * (q2q3 - q0q1));
-    bx = sqrtf(hx * hx + hy * hy);
+    bx = sqrt(hx * hx + hy * hy);
     bz = 2.0f * (mx * (q1q3 - q0q2) + my * (q2q3 + q0q1) + mz * (0.5f - q1q1 - q2q2));
 
     // Estimated direction of gravity and magnetic field
@@ -126,7 +127,7 @@ void Mahony::update6DOF(float gx, float gy, float gz, float ax, float ay, float 
   if (alen2 > config_alen2_min && alen2 < config_alen2_max) {
 
     //Normalise accelerometer measurement
-    recipNorm = 1.0 / sqrtf(alen2);
+    recipNorm = rsqrt_approx(alen2);
     ax *= recipNorm;
     ay *= recipNorm;
     az *= recipNorm;
@@ -176,7 +177,7 @@ void Mahony::update6DOF(float gx, float gy, float gz, float ax, float ay, float 
   q3 += (qa * gz + qb * gy - qc * gx);
 
   // Normalise quaternion
-  recipNorm = 1.0f/sqrtf(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
+  recipNorm = rsqrt_approx(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
   q0 *= recipNorm;
   q1 *= recipNorm;
   q2 *= recipNorm;

--- a/src/madflight.h
+++ b/src/madflight.h
@@ -206,43 +206,54 @@ void madflight_setup() {
     Serial.println("Processor (MF_MCU_NAME): " MF_MCU_NAME);
   #endif
 
+  //MF_XXX compiler options
+  Serial.print("Compiler Flags:");
+  #ifdef MF_APPROX_MATH
+    Serial.print(" MF_APPROX_MATH=on");
+  #else
+    Serial.print(" MF_APPROX_MATH=off");
+  #endif
+  Serial.println();
+
   //arduino defines
+  Serial.print("Arduino Flags:");
   #ifdef ARDUINO_BOARD
-    Serial.println("-D ARDUINO_BOARD=" ARDUINO_BOARD );
+    Serial.print(" ARDUINO_BOARD=" ARDUINO_BOARD );
   #endif
   #ifdef ARDUINO_VARIANT
-    Serial.println("-D ARDUINO_VARIANT=" ARDUINO_VARIANT );
+    Serial.print(" ARDUINO_VARIANT=" ARDUINO_VARIANT );
   #endif
   #ifdef ARDUINO_HOST_OS
-    Serial.println("-D ARDUINO_HOST_OS=" ARDUINO_HOST_OS ); //only arduino IDE, not PlatformIO
+    Serial.print(" ARDUINO_HOST_OS=" ARDUINO_HOST_OS ); //only arduino IDE, not PlatformIO
   #endif
   #ifdef ARDUINO_FQBN
-    Serial.println("-D ARDUINO_FQBN=" ARDUINO_FQBN ); //only arduino IDE, not PlatformIO
+    Serial.print(" ARDUINO_FQBN=" ARDUINO_FQBN ); //only arduino IDE, not PlatformIO
   #endif
   #ifdef ARDUINO
-    Serial.println("-D ARDUINO=" mf_str(ARDUINO));
+    Serial.print(" ARDUINO=" mf_str(ARDUINO));
   #endif
   #ifdef CORE_DEBUG_LEVEL
-    Serial.println("-D CORE_DEBUG_LEVEL=" mf_str(CORE_DEBUG_LEVEL));
+    Serial.print(" CORE_DEBUG_LEVEL=" mf_str(CORE_DEBUG_LEVEL));
   #endif
   #ifdef ARDUINO_RUNNING_CORE
-    Serial.println("-D ARDUINO_RUNNING_CORE=" mf_str(ARDUINO_RUNNING_CORE));
+    Serial.print(" ARDUINO_RUNNING_CORE=" mf_str(ARDUINO_RUNNING_CORE));
   #endif
   #ifdef ARDUINO_EVENT_RUNNING_CORE
-    Serial.println("-D ARDUINO_EVENT_RUNNING_CORE=" mf_str(ARDUINO_EVENT_RUNNING_CORE));
+    Serial.print(" ARDUINO_EVENT_RUNNING_CORE=" mf_str(ARDUINO_EVENT_RUNNING_CORE));
   #endif
   #ifdef ARDUINO_USB_MODE
-    Serial.println("-D ARDUINO_USB_MODE=" mf_str(ARDUINO_USB_MODE));
+    Serial.print(" ARDUINO_USB_MODE=" mf_str(ARDUINO_USB_MODE));
   #endif
   #ifdef ARDUINO_USB_CDC_ON_BOOT
-    Serial.println("-D ARDUINO_USB_CDC_ON_BOOT=" mf_str(ARDUINO_USB_CDC_ON_BOOT));
+    Serial.print(" ARDUINO_USB_CDC_ON_BOOT=" mf_str(ARDUINO_USB_CDC_ON_BOOT));
   #endif
   #ifdef ARDUINO_USB_MSC_ON_BOOT
-    Serial.println("-D ARDUINO_USB_MSC_ON_BOOT=" mf_str(ARDUINO_USB_MSC_ON_BOOT));
+    Serial.print(" ARDUINO_USB_MSC_ON_BOOT=" mf_str(ARDUINO_USB_MSC_ON_BOOT));
   #endif
   #ifdef ARDUINO_USB_DFU_ON_BOOT
-    Serial.println("-D ARDUINO_USB_DFU_ON_BOOT=" mf_str(ARDUINO_USB_DFU_ON_BOOT));
+    Serial.print(" ARDUINO_USB_DFU_ON_BOOT=" mf_str(ARDUINO_USB_DFU_ON_BOOT));
   #endif
+  Serial.println();
 
   // INFO - Rerun CFG to show output after startup delay
   cfg.setup(madflight_board, madflight_config);

--- a/src/tbx/maths.cpp
+++ b/src/tbx/maths.cpp
@@ -1,3 +1,5 @@
+//NOTE: modified for madflight
+
 /*
  * This file is part of Cleanflight and Betaflight.
  *
@@ -188,7 +190,9 @@ float asin_approx(float x)
     return (M_PIf * 0.5f) - acos_approx(x);
 }
 
-#endif
+#endif //#if defined(MF_APPROX_MATH)
+
+#if 0 //disable unused functions
 
 int gcd(int num, int denom)
 {
@@ -427,3 +431,5 @@ float smoothStepUpTransition(const float x, const float center, const float widt
         return cubicBlend(t);
     }
 }
+
+#endif //disable unused functions

--- a/src/tbx/maths.cpp
+++ b/src/tbx/maths.cpp
@@ -1,0 +1,429 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include "maths.h"
+
+#if defined(MF_APPROX_MATH)
+
+//see https://en.wikipedia.org/wiki/Fast_inverse_square_root
+float rsqrt_approx( float number )
+{
+	uint32_t i;
+	float x2, y;
+	const float threehalfs = 1.5F;
+	x2 = number * 0.5f;
+	y  = number;
+	i  = * (uint32_t*) &y;                  // evil floating point bit level hacking
+	i  = 0x5f3759df - (i >> 1);             // what the fuck?
+	y  = * (float*) &i;
+	y  = y * (threehalfs - (x2 * y * y));   // 1st iteration - relative error ~ 2000ppm
+	y  = y * (threehalfs - (x2 * y * y));   // 2nd iteration - relative error ~ 5ppm
+	return y;
+}
+
+
+static inline float sin_poly5_r(float r, float s)
+{
+    // Pre-scaled for u = r*(π/2)
+    const float c0 =  0x1.921f1cp0f; // 1.5707871913909912109375
+    const float c1 = -0x1.4a974p-1f; // -0.6456851959228515625
+    const float c2 =  0x1.3db294p-4f; // 7.756288349628448486328125e-2
+    return r * ((c2 * s + c1) * s + c0);
+}
+
+static inline float cos_poly6_r(float s)
+{
+    const float d1 = -0x1.3bd39cp0f; // -1.2336976528167724609375
+    const float d2 =  0x1.03bp-2f; // 0.25360107421875
+    const float d3 = -0x1.4e5eecp-6f; // -2.04083733260631561279296875e-2
+    return ((d3 * s + d2) * s + d1) * s + 1.0f;
+}
+
+// ---- Range reduction ----
+static inline void range_reduce(float x, float *r_out, int *q_out)
+{
+    float t  = x * INV_PIO2;
+    float qf = roundf(t);
+    *q_out   = (int)qf;
+    *r_out   = t - qf;
+}
+
+// ---- Quadrant mapping helpers ----
+// r ∈ [-0.5, 0.5], q is quadrant index (…,-1,0,1,2,3,4,…).
+static inline float sinf_quadrant_r(float r, int q)
+{
+    float s = r * r;
+
+    q &= 3;
+    if (q & 1) { // odd: use cos, sign handled below
+        float v = cos_poly6_r(s);
+        return (q & 2) ? -v : v;
+    } else {     // even: use sin
+        float v = sin_poly5_r(r, s);
+        return (q & 2) ? -v : v;
+    }
+}
+
+static inline float cosf_quadrant_r(float r, int q)
+{
+    float s = r * r;
+
+    q &= 3;
+    if (q & 1) { // odd: -sin, sign handled below
+        float v = -sin_poly5_r(r, s);
+        return (q & 2) ? -v : v;   // q=1 -> -sin, q=3 -> +sin
+    } else {     // even: cos
+        float v = cos_poly6_r(s);
+        return (q & 2) ? -v : v;   // q=2 -> -cos
+    }
+}
+
+static inline void sincosf_quadrant_r(float r, int q, float *out_s, float *out_c)
+{
+    float s = r * r;
+
+    q &= 3;
+    float sb = sin_poly5_r(r, s);
+    float cb = cos_poly6_r(s);
+
+    // map to base values in registers
+    float sv = (q & 1) ? cb  : sb;   // odd quadrants: use cos
+    float cv = (q & 1) ? -sb : cb;   // odd quadrants: cos->sin mapping
+
+    // flip signs for quadrants 2 and 3
+    if (q & 2) { sv = -sv; cv = -cv; }
+
+    *out_s = sv;
+    *out_c = cv;
+}
+
+float sin_approx(float x)
+{
+    int q; // quadrant index
+    float r; // remainder in [-0.5, 0,5]
+    range_reduce(x, &r, &q);
+    return sinf_quadrant_r(r, q);
+}
+
+float cos_approx(float x)
+{
+    int q; // quadrant index
+    float r; // remainder in [-0.5,]
+    range_reduce(x, &r, &q);
+    return cosf_quadrant_r(r, q);
+}
+
+void sincos_approx(float x, float *out_s, float *out_c)
+{
+    int q; // quadrant index
+    float r; // remainder in [-0.5,]
+    range_reduce(x, &r, &q);
+    sincosf_quadrant_r(r, q, out_s, out_c);
+}
+
+// Initial implementation by Crashpilot1000 (https://github.com/Crashpilot1000/HarakiriWebstore1/blob/396715f73c6fcf859e0db0f34e12fe44bace6483/src/mw.c#L1292)
+// Polynomial coefficients by Andor (http://www.dsprelated.com/showthread/comp.dsp/21872-1.php) optimized by Ledvinap to save one multiplication
+// Max absolute error 0,000027 degree
+// atan2_approx maximum absolute error = 7.152557e-07 rads (4.098114e-05 degree)
+float atan2_approx(float y, float x)
+{
+    #define atanPolyCoef1  3.14551665884836e-07f
+    #define atanPolyCoef2  0.99997356613987f
+    #define atanPolyCoef3  0.14744007058297684f
+    #define atanPolyCoef4  0.3099814292351353f
+    #define atanPolyCoef5  0.05030176425872175f
+    #define atanPolyCoef6  0.1471039133652469f
+    #define atanPolyCoef7  0.6444640676891548f
+
+    float res, absX, absY;
+    absX = fabsf(x);
+    absY = fabsf(y);
+    res  = MAX(absX, absY);
+    if (res) res = MIN(absX, absY) / res;
+    else res = 0.0f;
+    res = -((((atanPolyCoef5 * res - atanPolyCoef4) * res - atanPolyCoef3) * res - atanPolyCoef2) * res - atanPolyCoef1) / ((atanPolyCoef7 * res + atanPolyCoef6) * res + 1.0f);
+    if (absY > absX) res = (M_PIf / 2.0f) - res;
+    if (x < 0) res = M_PIf - res;
+    if (y < 0) res = -res;
+    return res;
+}
+
+// http://http.developer.nvidia.com/Cg/acos.html
+// Handbook of Mathematical Functions
+// M. Abramowitz and I.A. Stegun, Ed.
+// acos_approx maximum absolute error = 6.760856e-05 rads (3.873685e-03 degree)
+float acos_approx(float x)
+{
+    float xa = fabsf(x);
+    float result = sqrtf(1.0f - xa) * (1.5707288f + xa * (-0.2121144f + xa * (0.0742610f + (-0.0187293f * xa))));
+    if (x < 0.0f)
+        return M_PIf - result;
+    else
+        return result;
+}
+
+float asin_approx(float x)
+{
+    return (M_PIf * 0.5f) - acos_approx(x);
+}
+
+#endif
+
+int gcd(int num, int denom)
+{
+    if (denom == 0) {
+        return num;
+    }
+
+    return gcd(denom, num % denom);
+}
+
+int32_t applyDeadband(const int32_t value, const int32_t deadband)
+{
+    if (abs(value) < deadband) {
+        return 0;
+    }
+
+    return value >= 0 ? value - deadband : value + deadband;
+}
+
+float fapplyDeadband(const float value, const float deadband)
+{
+    if (fabsf(value) < deadband) {
+        return 0;
+    }
+
+    return value >= 0 ? value - deadband : value + deadband;
+}
+
+void devClear(stdev_t *dev)
+{
+    dev->m_n = 0;
+}
+
+void devPush(stdev_t *dev, float x)
+{
+    dev->m_n++;
+    if (dev->m_n == 1) {
+        dev->m_oldM = dev->m_newM = x;
+        dev->m_oldS = 0.0f;
+    } else {
+        dev->m_newM = dev->m_oldM + (x - dev->m_oldM) / dev->m_n;
+        dev->m_newS = dev->m_oldS + (x - dev->m_oldM) * (x - dev->m_newM);
+        dev->m_oldM = dev->m_newM;
+        dev->m_oldS = dev->m_newS;
+    }
+}
+
+float devVariance(stdev_t *dev)
+{
+    return ((dev->m_n > 1) ? dev->m_newS / (dev->m_n - 1) : 0.0f);
+}
+
+float devStandardDeviation(stdev_t *dev)
+{
+    return sqrtf(devVariance(dev));
+}
+
+float degreesToRadians(int16_t degrees)
+{
+    return degrees * RAD;
+}
+
+int scaleRange(int x, int srcFrom, int srcTo, int destFrom, int destTo)
+{
+    long int a = ((long int) destTo - (long int) destFrom) * ((long int) x - (long int) srcFrom);
+    long int b = (long int) srcTo - (long int) srcFrom;
+    return (a / b) + destFrom;
+}
+
+float scaleRangef(float x, float srcFrom, float srcTo, float destFrom, float destTo)
+{
+    float a = (destTo - destFrom) * (x - srcFrom);
+    float b = srcTo - srcFrom;
+    return (a / b) + destFrom;
+}
+
+void scaleRangefInit(scaleRangef_t *scale, float srcFrom, float srcTo, float destFrom, float destTo)
+{
+    float range_src = srcTo - srcFrom;
+    float range_dest = destTo - destFrom;
+    scale->scale = range_dest / range_src;
+    scale->offset = destFrom - (srcFrom * scale->scale);
+}
+
+float scaleRangefApply(scaleRangef_t *scale, float x)
+{
+    return (x * scale->scale) + scale->offset;
+}
+
+// Quick median filter implementation
+// (c) N. Devillard - 1998
+// http://ndevilla.free.fr/median/median.pdf
+#define QMF_SORT(a,b) { if ((a)>(b)) QMF_SWAP((a),(b)); }
+#define QMF_SWAP(a,b) { int32_t temp=(a);(a)=(b);(b)=temp; }
+#define QMF_COPY(p,v,n) { int32_t i; for (i=0; i<n; i++) p[i]=v[i]; }
+#define QMF_SORTF(a,b) { if ((a)>(b)) QMF_SWAPF((a),(b)); }
+#define QMF_SWAPF(a,b) { float temp=(a);(a)=(b);(b)=temp; }
+
+int32_t quickMedianFilter3(const int32_t * v)
+{
+    int32_t p[3];
+    QMF_COPY(p, v, 3);
+
+    QMF_SORT(p[0], p[1]); QMF_SORT(p[1], p[2]); QMF_SORT(p[0], p[1]) ;
+    return p[1];
+}
+
+int32_t quickMedianFilter5(const int32_t * v)
+{
+    int32_t p[5];
+    QMF_COPY(p, v, 5);
+
+    QMF_SORT(p[0], p[1]); QMF_SORT(p[3], p[4]); QMF_SORT(p[0], p[3]);
+    QMF_SORT(p[1], p[4]); QMF_SORT(p[1], p[2]); QMF_SORT(p[2], p[3]);
+    QMF_SORT(p[1], p[2]);
+    return p[2];
+}
+
+int32_t quickMedianFilter7(const int32_t * v)
+{
+    int32_t p[7];
+    QMF_COPY(p, v, 7);
+
+    QMF_SORT(p[0], p[5]); QMF_SORT(p[0], p[3]); QMF_SORT(p[1], p[6]);
+    QMF_SORT(p[2], p[4]); QMF_SORT(p[0], p[1]); QMF_SORT(p[3], p[5]);
+    QMF_SORT(p[2], p[6]); QMF_SORT(p[2], p[3]); QMF_SORT(p[3], p[6]);
+    QMF_SORT(p[4], p[5]); QMF_SORT(p[1], p[4]); QMF_SORT(p[1], p[3]);
+    QMF_SORT(p[3], p[4]);
+    return p[3];
+}
+
+int32_t quickMedianFilter9(const int32_t * v)
+{
+    int32_t p[9];
+    QMF_COPY(p, v, 9);
+
+    QMF_SORT(p[1], p[2]); QMF_SORT(p[4], p[5]); QMF_SORT(p[7], p[8]);
+    QMF_SORT(p[0], p[1]); QMF_SORT(p[3], p[4]); QMF_SORT(p[6], p[7]);
+    QMF_SORT(p[1], p[2]); QMF_SORT(p[4], p[5]); QMF_SORT(p[7], p[8]);
+    QMF_SORT(p[0], p[3]); QMF_SORT(p[5], p[8]); QMF_SORT(p[4], p[7]);
+    QMF_SORT(p[3], p[6]); QMF_SORT(p[1], p[4]); QMF_SORT(p[2], p[5]);
+    QMF_SORT(p[4], p[7]); QMF_SORT(p[4], p[2]); QMF_SORT(p[6], p[4]);
+    QMF_SORT(p[4], p[2]);
+    return p[4];
+}
+
+float quickMedianFilter3f(const float * v)
+{
+    float p[3];
+    QMF_COPY(p, v, 3);
+
+    QMF_SORTF(p[0], p[1]); QMF_SORTF(p[1], p[2]); QMF_SORTF(p[0], p[1]) ;
+    return p[1];
+}
+
+float quickMedianFilter5f(const float * v)
+{
+    float p[5];
+    QMF_COPY(p, v, 5);
+
+    QMF_SORTF(p[0], p[1]); QMF_SORTF(p[3], p[4]); QMF_SORTF(p[0], p[3]);
+    QMF_SORTF(p[1], p[4]); QMF_SORTF(p[1], p[2]); QMF_SORTF(p[2], p[3]);
+    QMF_SORTF(p[1], p[2]);
+    return p[2];
+}
+
+float quickMedianFilter7f(const float * v)
+{
+    float p[7];
+    QMF_COPY(p, v, 7);
+
+    QMF_SORTF(p[0], p[5]); QMF_SORTF(p[0], p[3]); QMF_SORTF(p[1], p[6]);
+    QMF_SORTF(p[2], p[4]); QMF_SORTF(p[0], p[1]); QMF_SORTF(p[3], p[5]);
+    QMF_SORTF(p[2], p[6]); QMF_SORTF(p[2], p[3]); QMF_SORTF(p[3], p[6]);
+    QMF_SORTF(p[4], p[5]); QMF_SORTF(p[1], p[4]); QMF_SORTF(p[1], p[3]);
+    QMF_SORTF(p[3], p[4]);
+    return p[3];
+}
+
+float quickMedianFilter9f(const float * v)
+{
+    float p[9];
+    QMF_COPY(p, v, 9);
+
+    QMF_SORTF(p[1], p[2]); QMF_SORTF(p[4], p[5]); QMF_SORTF(p[7], p[8]);
+    QMF_SORTF(p[0], p[1]); QMF_SORTF(p[3], p[4]); QMF_SORTF(p[6], p[7]);
+    QMF_SORTF(p[1], p[2]); QMF_SORTF(p[4], p[5]); QMF_SORTF(p[7], p[8]);
+    QMF_SORTF(p[0], p[3]); QMF_SORTF(p[5], p[8]); QMF_SORTF(p[4], p[7]);
+    QMF_SORTF(p[3], p[6]); QMF_SORTF(p[1], p[4]); QMF_SORTF(p[2], p[5]);
+    QMF_SORTF(p[4], p[7]); QMF_SORTF(p[4], p[2]); QMF_SORTF(p[6], p[4]);
+    QMF_SORTF(p[4], p[2]);
+    return p[4];
+}
+
+void arraySubInt32(int32_t *dest, const int32_t *array1, const int32_t *array2, int count)
+{
+    for (int i = 0; i < count; i++) {
+        dest[i] = array1[i] - array2[i];
+    }
+}
+
+int16_t qPercent(fix12_t q)
+{
+    return (100 * q) >> 12;
+}
+
+int16_t qMultiply(fix12_t q, int16_t input)
+{
+    return (input *  q) >> 12;
+}
+
+fix12_t  qConstruct(int16_t num, int16_t den)
+{
+    return (num << 12) / den;
+}
+
+// Cubic polynomial blending function
+static float cubicBlend(const float t)
+{
+    return t * t * (3.0f - 2.0f * t);
+}
+
+// Smooth step-up transition function from 0 to 1
+float smoothStepUpTransition(const float x, const float center, const float width)
+{
+    const float half_width = width * 0.5f;
+    const float left_limit = center - half_width;
+    const float right_limit = center + half_width;
+
+    if (x < left_limit) {
+        return 0.0f;
+    } else if (x > right_limit) {
+        return 1.0f;
+    } else {
+        const float t = (x - left_limit) / width; // Normalize x within the range
+        return cubicBlend(t);
+    }
+}

--- a/src/tbx/maths.h
+++ b/src/tbx/maths.h
@@ -1,0 +1,196 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#if defined(MF_APPROX_MATH)
+    float rsqrt_approx(float x);
+    float sin_approx(float x);
+    float cos_approx(float x);
+    void sincos_approx(float x, float *out_s, float *out_c);
+    float atan2_approx(float y, float x);
+    float acos_approx(float x);
+    float asin_approx(float x);
+    #define tan_approx(x)       (sin_approx(x) / cos_approx(x))
+    float exp_approx(float val);
+    float log_approx(float val);
+    float pow_approx(float a, float b);
+#else
+    #include <math.h>
+    static inline float rsqrt_approx(float x) {
+        return 1.0 / sqrt(x);
+    }  
+    #define sin_approx(x)       sinf(x)
+    #define cos_approx(x)       cosf(x)
+    // slower non fast math version
+    static inline void sincos_approx(float x, float *out_s, float *out_c) {
+        *out_s = sinf(x);
+        *out_c = cosf(x);
+    }
+    #define atan2_approx(y,x)   atan2f(y,x)
+    #define acos_approx(x)      acosf(x)
+    #define asin_approx(x)      asinf(x)
+    #define tan_approx(x)       tanf(x)
+    #define exp_approx(x)       expf(x)
+    #define log_approx(x)       logf(x)
+    #define pow_approx(a, b)    powf(b, a)
+#endif
+
+#ifndef sq
+#define sq(x) ((x)*(x))
+#endif
+#define power3(x) ((x)*(x)*(x))
+#define power5(x) ((x)*(x)*(x)*(x)*(x))
+
+// Use floating point M_PI instead explicitly.
+#define M_PIf       3.14159265358979323846f
+#define M_EULERf    2.71828182845904523536f
+#define INV_PIO2    (2.0f / M_PIf)
+
+#define RAD    (M_PIf / 180.0f)
+#define DEGREES_TO_DECIDEGREES(angle) ((angle) * 10)
+#define DECIDEGREES_TO_DEGREES(angle) ((angle) / 10)
+#define DECIDEGREES_TO_RADIANS(angle) ((angle) / 10.0f * 0.0174532925f)
+#define DEGREES_TO_RADIANS(angle) ((angle) * RAD)
+#define RADIANS_TO_DEGREES(angle) ((angle) / RAD)
+
+#define CM_S_TO_KM_H(centimetersPerSecond) ((centimetersPerSecond) * 36 / 1000)
+#define CM_S_TO_MPH(centimetersPerSecond) ((centimetersPerSecond) * 10000 / 5080 / 88)
+
+#ifndef MIN
+#define MIN(a,b) \
+  __extension__ ({ __typeof__ (a) _a = (a); \
+  __typeof__ (b) _b = (b); \
+  _a < _b ? _a : _b; })
+#endif
+
+#ifndef MAX
+#define MAX(a,b) \
+  __extension__ ({ __typeof__ (a) _a = (a); \
+  __typeof__ (b) _b = (b); \
+  _a > _b ? _a : _b; })
+#endif
+
+#define ABS(x) \
+  __extension__ ({ __typeof__ (x) _x = (x); \
+  _x > 0 ? _x : -_x; })
+#define SIGN(x) \
+  __extension__ ({ __typeof__ (x) _x = (x); \
+  (_x > 0) - (_x < 0); })
+
+#define Q12 (1 << 12)
+
+#define HZ_TO_INTERVAL(x) (1.0f / (x))
+#define HZ_TO_INTERVAL_US(x) (1000000 / (x))
+
+#define SCALE_FACTOR(in_start, in_end, out_start, out_end) \
+    ((float)((out_end) - (out_start)) / (float)((in_end) - (in_start)))
+
+#define SCALE_OFFSET(in_start, in_end, out_start, out_end) \
+    ((float)(out_start) - (SCALE_FACTOR((in_start), (in_end), (out_start), (out_end)) * (float)(in_start)))
+
+#define DEFINE_SCALE_FN(name, in_start, in_end, out_start, out_end)              \
+    static inline float name(float input) {                                      \
+        return (input * (SCALE_FACTOR(in_start, in_end, out_start, out_end)))    \
+                      + (SCALE_OFFSET(in_start, in_end, out_start, out_end));    \
+    }
+
+typedef struct scaleRangef_s {
+    float offset;
+    float scale;
+} scaleRangef_t;
+
+typedef int32_t fix12_t;
+
+typedef struct stdev_s {
+    float m_oldM, m_newM, m_oldS, m_newS;
+    int m_n;
+} stdev_t;
+
+// Floating point Euler angles.
+// Be carefull, could be either of degrees or radians.
+typedef struct fp_angles {
+    float roll;
+    float pitch;
+    float yaw;
+} fp_angles_def;
+
+typedef union {
+    float raw[3];
+    fp_angles_def angles;
+} fp_angles_t;
+
+int gcd(int num, int denom);
+int32_t applyDeadband(int32_t value, int32_t deadband);
+float fapplyDeadband(float value, float deadband);
+
+void devClear(stdev_t *dev);
+void devPush(stdev_t *dev, float x);
+float devVariance(stdev_t *dev);
+float devStandardDeviation(stdev_t *dev);
+float degreesToRadians(int16_t degrees);
+
+int scaleRange(int x, int srcFrom, int srcTo, int destFrom, int destTo);
+float scaleRangef(float x, float srcFrom, float srcTo, float destFrom, float destTo);
+void scaleRangefInit(scaleRangef_t *scale, float srcFrom, float srcTo, float destFrom, float destTo);
+float scaleRangefApply(scaleRangef_t *scale, float x);
+
+int32_t quickMedianFilter3(const int32_t * v);
+int32_t quickMedianFilter5(const int32_t * v);
+int32_t quickMedianFilter7(const int32_t * v);
+int32_t quickMedianFilter9(const int32_t * v);
+
+float quickMedianFilter3f(const float * v);
+float quickMedianFilter5f(const float * v);
+float quickMedianFilter7f(const float * v);
+float quickMedianFilter9f(const float * v);
+
+
+void arraySubInt32(int32_t *dest, const int32_t *array1, const int32_t *array2, int count);
+
+int16_t qPercent(fix12_t q);
+int16_t qMultiply(fix12_t q, int16_t input);
+fix12_t qConstruct(int16_t num, int16_t den);
+
+float smoothStepUpTransition(const float x, const float center, const float width);
+
+#ifndef constrain
+    static inline int constrain(int amt, int low, int high)
+    {
+        if (amt < low)
+            return low;
+        else if (amt > high)
+            return high;
+        else
+            return amt;
+    }
+#endif
+
+static inline float constrainf(float amt, float low, float high)
+{
+    if (amt < low)
+        return low;
+    else if (amt > high)
+        return high;
+    else
+        return amt;
+}

--- a/src/tbx/maths.h
+++ b/src/tbx/maths.h
@@ -1,3 +1,5 @@
+//NOTE: modified for madflight
+
 /*
  * This file is part of Cleanflight and Betaflight.
  *
@@ -34,6 +36,24 @@
     float exp_approx(float val);
     float log_approx(float val);
     float pow_approx(float a, float b);
+
+    #define M_PIf       3.14159265358979323846f
+    #define INV_PIO2    (2.0f / M_PIf)
+
+    #ifndef MIN
+    #define MIN(a,b) \
+    __extension__ ({ __typeof__ (a) _a = (a); \
+    __typeof__ (b) _b = (b); \
+    _a < _b ? _a : _b; })
+    #endif
+
+    #ifndef MAX
+    #define MAX(a,b) \
+    __extension__ ({ __typeof__ (a) _a = (a); \
+    __typeof__ (b) _b = (b); \
+    _a > _b ? _a : _b; })
+    #endif
+
 #else
     #include <math.h>
     static inline float rsqrt_approx(float x) {
@@ -55,6 +75,8 @@
     #define pow_approx(a, b)    powf(b, a)
 #endif
 
+#if 0 //disable unused functions
+
 #ifndef sq
 #define sq(x) ((x)*(x))
 #endif
@@ -62,9 +84,8 @@
 #define power5(x) ((x)*(x)*(x)*(x)*(x))
 
 // Use floating point M_PI instead explicitly.
-#define M_PIf       3.14159265358979323846f
+
 #define M_EULERf    2.71828182845904523536f
-#define INV_PIO2    (2.0f / M_PIf)
 
 #define RAD    (M_PIf / 180.0f)
 #define DEGREES_TO_DECIDEGREES(angle) ((angle) * 10)
@@ -76,19 +97,7 @@
 #define CM_S_TO_KM_H(centimetersPerSecond) ((centimetersPerSecond) * 36 / 1000)
 #define CM_S_TO_MPH(centimetersPerSecond) ((centimetersPerSecond) * 10000 / 5080 / 88)
 
-#ifndef MIN
-#define MIN(a,b) \
-  __extension__ ({ __typeof__ (a) _a = (a); \
-  __typeof__ (b) _b = (b); \
-  _a < _b ? _a : _b; })
-#endif
 
-#ifndef MAX
-#define MAX(a,b) \
-  __extension__ ({ __typeof__ (a) _a = (a); \
-  __typeof__ (b) _b = (b); \
-  _a > _b ? _a : _b; })
-#endif
 
 #define ABS(x) \
   __extension__ ({ __typeof__ (x) _x = (x); \
@@ -194,3 +203,5 @@ static inline float constrainf(float amt, float low, float high)
     else
         return amt;
 }
+
+#endif

--- a/src/tbx/quaternion.cpp
+++ b/src/tbx/quaternion.cpp
@@ -21,29 +21,28 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ===========================================================================================*/
-
 #include "quaternion.h"
-#include <math.h>
 
-static float constrain(float x, float min, float max) {
+#include "maths.h" //fast approximations of sin, cos, etc
+
+static float _constrain(float x, float min, float max) {
     return (x < min ? min : (x > max ? max : x));
 }
 
-static constexpr float rad_to_deg = 180 / M_PI;
-static constexpr float deg_to_rad = M_PI / 180;
+static constexpr float rad_to_deg = 180.0f / 3.14159265358979323846f;
+static constexpr float deg_to_rad = 3.14159265358979323846f / 180.0f;
+static constexpr float deg_to_rad_2 = 3.14159265358979323846f / 360.0f;
 
 void quaternion_from_euler_deg(float q[4], const float euler_rpy[3]) {
-  float eul[3];
-  eul[0] = euler_rpy[0] * deg_to_rad; //roll
-  eul[1] = euler_rpy[1] * deg_to_rad; //pitch
-  eul[2] = euler_rpy[2] * deg_to_rad; //yaw
+  float eul_div2[3];
+  eul_div2[0] = euler_rpy[0] * deg_to_rad_2; //roll
+  eul_div2[1] = euler_rpy[1] * deg_to_rad_2; //pitch
+  eul_div2[2] = euler_rpy[2] * deg_to_rad_2; //yaw
 
-  float c0 = cos(eul[0]/2);
-  float s0 = sin(eul[0]/2);
-  float c1 = cos(eul[1]/2);
-  float s1 = sin(eul[1]/2);
-  float c2 = cos(eul[2]/2);
-  float s2 = sin(eul[2]/2);
+  float s0,s1,s2,c0,c1,c2;
+  sincos_approx(eul_div2[0], &s0, &c0);
+  sincos_approx(eul_div2[1], &s1, &c1);
+  sincos_approx(eul_div2[2], &s2, &c2);
   float c0c1 = c0*c1;
   float s0s1 = s0*s1;
   float s0c1 = s0*c1;
@@ -52,12 +51,17 @@ void quaternion_from_euler_deg(float q[4], const float euler_rpy[3]) {
   q[1] = s0c1*c2 - c0s1*s2;
   q[2] = c0s1*c2 + s0c1*s2;
   q[3] = c0c1*s2 - s0s1*c2;
+
+  //Serial.printf("euler_rpy %f %f %f    ", euler_rpy[0], euler_rpy[1], euler_rpy[2]);
+  //Serial.printf("sincos %f %f %f %f %f %f    ", s0,s1,s2,c0,c1,c2);
+  //Serial.printf("q=%f %f %f %f\n", q[0], q[1], q[2], q[3]);
+  //delay(100);
 }
 
 void quaternion_to_euler_deg(float euler_rpy[3], const float q[4]) {
-  euler_rpy[0] = atan2(q[0]*q[1] + q[2]*q[3], 0.5f - q[1]*q[1] - q[2]*q[2]) * rad_to_deg; //degrees - roll right is positive
-  euler_rpy[1] = asin(constrain(-2.0f * (q[1]*q[3] - q[0]*q[2]), -1.0, 1.0)) * rad_to_deg; //degrees - pitch up is positive - use constrain() to prevent NaN due to rounding
-  euler_rpy[2] = atan2(q[1]*q[2] + q[0]*q[3], 0.5f - q[2]*q[2] - q[3]*q[3]) * rad_to_deg; //degrees - yaw right is positive
+  euler_rpy[0] = atan2_approx(q[0]*q[1] + q[2]*q[3], 0.5f - q[1]*q[1] - q[2]*q[2]) * rad_to_deg; //degrees - roll right is positive
+  euler_rpy[1] = asin_approx(_constrain(-2.0f * (q[1]*q[3] - q[0]*q[2]), -1.0, 1.0)) * rad_to_deg; //degrees - pitch up is positive - use constrain() to prevent NaN due to rounding
+  euler_rpy[2] = atan2_approx(q[1]*q[2] + q[0]*q[3], 0.5f - q[2]*q[2] - q[3]*q[3]) * rad_to_deg; //degrees - yaw right is positive
 }
 
 void quaternion_mult(float result[4], const float p[4], const float q[4]) {
@@ -86,7 +90,7 @@ void quaternion_normalize(float q[4]) {
   if(norm2 <= 0) {
     quaternion_init(q);
   }else{
-    float inv_norm = 1 / sqrt(norm2);
+    float inv_norm = rsqrt_approx(norm2);
     q[0] *= inv_norm;
     q[1] *= inv_norm;
     q[2] *= inv_norm;


### PR DESCRIPTION
RP2305 with ahr_gizmo MAHONY did not improve... Keeping the MF_APPROX_MATH option off by default
```
Compiler Flags: MF_APPROX_MATH=off

=== Wallclock Runtime - Measurement Period: 1.94 seconds ===

Module        Calls  Wallclock     Rt/call    Updates  Wallclock      Rt/upd
AHR          1000Hz    8.50%       85.00us     1000Hz    8.50%       85.00us


Compiler Flags: MF_APPROX_MATH=on

=== Wallclock Runtime - Measurement Period: 2.00 seconds ===

Module        Calls  Wallclock     Rt/call    Updates  Wallclock      Rt/upd
AHR          1001Hz    9.05%       90.45us     1001Hz    9.05%       90.45us
```